### PR TITLE
Make it work with Gatsby

### DIFF
--- a/src/carousel/index.js
+++ b/src/carousel/index.js
@@ -31,7 +31,7 @@ class Carousel extends Component {
 Carousel.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.element),
-    PropTypes.arrayOf(PropTypes.instanceOf(Element)),
+    PropTypes.arrayOf(PropTypes.instanceOf(typeof Element !== 'undefined' && Element)),
     PropTypes.func,
     PropTypes.oneOf([null])
   ]).isRequired

--- a/src/carousel/listener.js
+++ b/src/carousel/listener.js
@@ -203,7 +203,7 @@ export function handleWheel(e) {
 }
 
 export function handleVisibilityChange() {
-  this.changeWindow = document.visibilityState === 'visible';
+  this.changeWindow = typeof document !== 'undefined' && document.visibilityState === 'visible';
 }
 
 export function signupListener() {

--- a/src/carousel/slider.js
+++ b/src/carousel/slider.js
@@ -59,7 +59,7 @@ class Slider extends Component {
     this.autoplayTimer = null;
     ['', 'Webkit', 'Moz', 'O', 'ms'].every((prefix) => {
       const e = `${prefix}Transform`;
-      if (typeof document.body.style[e] !== 'undefined') {
+      if (typeof document !== 'undefined' && typeof document.body.style[e] !== 'undefined') {
         this.xform = e;
         return false;
       }

--- a/src/carousel/types.js
+++ b/src/carousel/types.js
@@ -90,7 +90,7 @@ const propTypes = {
   ]),
   lazyLoad: PropTypes.bool,
   nextArrow: PropTypes.oneOfType([
-    PropTypes.instanceOf(Element),
+    PropTypes.instanceOf(typeof Element !== 'undefined' && Element),
     PropTypes.element
   ]),
   onEdge: PropTypes.func,
@@ -101,7 +101,7 @@ const propTypes = {
   pauseOnFocus: PropTypes.bool,
   pauseOnHover: PropTypes.bool,
   prevArrow: PropTypes.oneOfType([
-    PropTypes.instanceOf(Element),
+    PropTypes.instanceOf(typeof Element !== 'undefined' && Element),
     PropTypes.element
   ]),
   responsive: PropTypes.array,
@@ -166,13 +166,13 @@ const arrowsPropTypes = {
   prevArrow: PropTypes.oneOfType([
     PropTypes.array,
     PropTypes.element,
-    PropTypes.instanceOf(Element),
+    PropTypes.instanceOf(typeof Element !== 'undefined' && Element),
     PropTypes.oneOf([null])
   ]),
   nextArrow: PropTypes.oneOfType([
     PropTypes.array,
     PropTypes.element,
-    PropTypes.instanceOf(Element),
+    PropTypes.instanceOf(typeof Element !== 'undefined' && Element),
     PropTypes.oneOf([null])
   ]),
   arrowsBlock: PropTypes.bool,


### PR DESCRIPTION
By conditionally referencing all objects and types only available in the DOM context (`Element` and `document`), this commit makes this lib work with GatsbyJS.

Before these changes, when trying to build with Gatsby we got the following build error:

```
5:26:44 PM: error Building static HTML failed
5:26:44 PM:   140 |   initialSlide: _propTypes["default"].oneOfType([_propTypes["default"].number, _propTypes["default"].bool]),
5:26:44 PM:   141 |   lazyLoad: _propTypes["default"].bool,
5:26:44 PM: > 142 |   nextArrow: _propTypes["default"].oneOfType([_propTypes["default"].instanceOf(Element), _propTypes["default"].element]),
5:26:44 PM:       | ^
5:26:44 PM:   143 |   onEdge: _propTypes["default"].func,
5:26:44 PM:   144 |   onInit: _propTypes["default"].func,
5:26:44 PM:   145 |   onLazyLoadError: _propTypes["default"].func,
5:26:44 PM: 
5:26:44 PM:   WebpackError: ReferenceError: Element is not defined
5:26:44 PM:   
5:26:44 PM:   - types.js:142 Object../node_modules/infinite-react-carousel/lib/carousel/type    s.js
5:26:44 PM:     node_modules/infinite-react-carousel/lib/carousel/types.js:142:1
5:26:44 PM:   
5:26:44 PM:   - slider.js:24 Object../node_modules/infinite-react-carousel/lib/carousel/slid    er.js
5:26:44 PM:     node_modules/infinite-react-carousel/lib/carousel/slider.js:24:14
5:26:44 PM:   
5:26:44 PM:   - index.js:12 Object../node_modules/infinite-react-carousel/lib/carousel/index    .js
5:26:44 PM:     node_modules/infinite-react-carousel/lib/carousel/index.js:12:38
5:26:44 PM:   
5:26:44 PM:   - index.js:14 Object../node_modules/infinite-react-carousel/lib/index.js
5:26:44 PM:     node_modules/infinite-react-carousel/lib/index.js:14:40
5:26:44 PM:   
5:26:44 PM:   - index.js:1 Module../src/pages/index.js
5:26:44 PM:     src/pages/index.js:1:1
5:26:44 PM:   
```